### PR TITLE
Add configurable dash ability and markers to third person controller

### DIFF
--- a/Assets/Invector-3rdPersonController_LITE/Scripts/CharacterController/vThirdPersonInput.cs
+++ b/Assets/Invector-3rdPersonController_LITE/Scripts/CharacterController/vThirdPersonInput.cs
@@ -12,6 +12,7 @@ namespace Invector.vCharacterController
         public KeyCode jumpInput = KeyCode.Space;
         public KeyCode strafeInput = KeyCode.Tab;
         public KeyCode sprintInput = KeyCode.LeftShift;
+        public KeyCode dashInput = KeyCode.E;
 
         [Header("Camera Input")]
         public string rotateCameraXInput = "Mouse X";
@@ -79,6 +80,7 @@ namespace Invector.vCharacterController
             SprintInput();
             StrafeInput();
             JumpInput();
+            DashInput();
         }
 
         public virtual void MoveInput()
@@ -125,6 +127,15 @@ namespace Invector.vCharacterController
                 cc.Sprint(true);
             else if (Input.GetKeyUp(sprintInput))
                 cc.Sprint(false);
+        }
+
+        /// <summary>
+        /// Input to trigger the dash behaviour.
+        /// </summary>
+        protected virtual void DashInput()
+        {
+            if (Input.GetKeyDown(dashInput))
+                cc.Dash();
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- add an editor-configurable dash input to the third person controller and expose dash distance
- implement dash coroutine that moves the character forward and spawns cube markers along the path
- extend the input handler to trigger the new dash ability with the E key

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68d9a1e1c77c832aa5c533443966e49e