### PR TITLE
Add configurable floating platform with key activation

### DIFF
--- a/Assets/Scripts.meta
+++ b/Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 178c628a060b409397f628250e93b1f1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Environment.meta
+++ b/Assets/Scripts/Environment.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f543be399f7f449b969fcc995993e75b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Environment/FloatingPlatform.cs
+++ b/Assets/Scripts/Environment/FloatingPlatform.cs
@@ -1,0 +1,201 @@
+using System.Collections;
+using UnityEngine;
+using YJ.Interaction;
+
+namespace YJ.Environment
+{
+    [RequireComponent(typeof(Rigidbody))]
+    public class FloatingPlatform : MonoBehaviour
+    {
+        private static readonly int ColorProperty = Shader.PropertyToID("_Color");
+        private static readonly int BaseColorProperty = Shader.PropertyToID("_BaseColor");
+
+        [Header("Movement")]
+        [SerializeField] private Transform startPoint;
+        [SerializeField] private Transform endPoint;
+        [SerializeField] private float travelTime = 3f;
+        [SerializeField] private AnimationCurve travelCurve = AnimationCurve.Linear(0f, 0f, 1f, 1f);
+        [SerializeField] private bool returnAfterReachEnd = true;
+        [SerializeField] private float waitTimeAtEachEnd = 1f;
+
+        [Header("Activation")]
+        [SerializeField] private float activationRange = 3f;
+        [SerializeField] private KeyCode activationKey = KeyCode.F;
+        [SerializeField] private string requiredKeyId;
+
+        [Header("Visuals")]
+        [SerializeField] private Renderer platformRenderer;
+        [SerializeField] private Color inactiveColor = Color.red;
+        [SerializeField] private Color readyColor = Color.green;
+        [SerializeField] private Color movingColor = new Color(0.5f, 1f, 0.5f);
+
+        private Vector3 _startPosition;
+        private Vector3 _endPosition;
+        private Coroutine _movementRoutine;
+        private Rigidbody _rigidbody;
+        private readonly MaterialPropertyBlock _propertyBlock = new MaterialPropertyBlock();
+        private bool _isAtStart = true;
+
+        private void Awake()
+        {
+            _rigidbody = GetComponent<Rigidbody>();
+            _rigidbody.isKinematic = true;
+
+            if (!platformRenderer)
+            {
+                platformRenderer = GetComponentInChildren<Renderer>();
+            }
+        }
+
+        private void Start()
+        {
+            CacheEndpoints();
+            transform.position = _startPosition;
+            _isAtStart = true;
+            UpdatePlatformColor();
+        }
+
+        private void Update()
+        {
+            var keyring = PlayerKeyring.LocalPlayer;
+            bool hasKey = string.IsNullOrWhiteSpace(requiredKeyId) || (keyring != null && keyring.HasKey(requiredKeyId));
+            bool isMoving = _movementRoutine != null;
+
+            if (!isMoving)
+            {
+                UpdatePlatformColor(hasKey);
+            }
+            else
+            {
+                UpdatePlatformColor(hasKey ? movingColor : inactiveColor);
+            }
+
+            if (!hasKey || isMoving)
+            {
+                return;
+            }
+
+            if (!PlayerKeyring.TryGetPlayerPosition(out var playerPosition))
+            {
+                return;
+            }
+
+            float sqrDistance = (playerPosition - transform.position).sqrMagnitude;
+            if (sqrDistance > activationRange * activationRange)
+            {
+                return;
+            }
+
+            if (Input.GetKeyDown(activationKey))
+            {
+                _movementRoutine = StartCoroutine(MovePlatformRoutine());
+            }
+        }
+
+        private IEnumerator MovePlatformRoutine()
+        {
+            CacheEndpoints();
+            Vector3 from = _isAtStart ? _startPosition : _endPosition;
+            Vector3 to = _isAtStart ? _endPosition : _startPosition;
+
+            yield return MoveBetweenPoints(from, to);
+            _isAtStart = !_isAtStart;
+
+            if (returnAfterReachEnd && !_isAtStart)
+            {
+                yield return new WaitForSeconds(waitTimeAtEachEnd);
+                yield return MoveBetweenPoints(_endPosition, _startPosition);
+                _isAtStart = true;
+            }
+
+            yield return new WaitForSeconds(waitTimeAtEachEnd);
+            _movementRoutine = null;
+        }
+
+        private IEnumerator MoveBetweenPoints(Vector3 from, Vector3 to)
+        {
+            float elapsed = 0f;
+            float duration = Mathf.Max(0.01f, travelTime);
+
+            while (elapsed < duration)
+            {
+                elapsed += Time.deltaTime;
+                float t = Mathf.Clamp01(elapsed / duration);
+                float curveT = travelCurve.Evaluate(t);
+                Vector3 targetPosition = Vector3.LerpUnclamped(from, to, curveT);
+                _rigidbody.MovePosition(targetPosition);
+                yield return null;
+            }
+
+            _rigidbody.MovePosition(to);
+        }
+
+        private void CacheEndpoints()
+        {
+            _startPosition = startPoint ? startPoint.position : transform.position;
+            _endPosition = endPoint ? endPoint.position : transform.position;
+        }
+
+        private void OnValidate()
+        {
+            if (travelTime < 0f)
+            {
+                travelTime = 0f;
+            }
+
+            if (activationRange < 0f)
+            {
+                activationRange = 0f;
+            }
+
+            if (waitTimeAtEachEnd < 0f)
+            {
+                waitTimeAtEachEnd = 0f;
+            }
+        }
+
+        private void OnDrawGizmos()
+        {
+            Vector3 startPos = startPoint ? startPoint.position : transform.position;
+            Vector3 endPos = endPoint ? endPoint.position : startPos;
+
+            Gizmos.color = Color.green;
+            Gizmos.DrawSphere(startPos, 0.15f);
+            Gizmos.color = Color.red;
+            Gizmos.DrawSphere(endPos, 0.15f);
+            Gizmos.color = Color.yellow;
+            Gizmos.DrawLine(startPos, endPos);
+        }
+
+        private void OnDrawGizmosSelected()
+        {
+            Gizmos.color = new Color(0f, 1f, 0f, 0.35f);
+            Gizmos.DrawWireSphere(transform.position, activationRange);
+        }
+
+        private void UpdatePlatformColor()
+        {
+            var keyring = PlayerKeyring.LocalPlayer;
+            bool hasKey = string.IsNullOrWhiteSpace(requiredKeyId) || (keyring != null && keyring.HasKey(requiredKeyId));
+            UpdatePlatformColor(hasKey ? readyColor : inactiveColor);
+        }
+
+        private void UpdatePlatformColor(bool hasKey)
+        {
+            UpdatePlatformColor(hasKey ? readyColor : inactiveColor);
+        }
+
+        private void UpdatePlatformColor(Color color)
+        {
+            if (!platformRenderer)
+            {
+                return;
+            }
+
+            platformRenderer.GetPropertyBlock(_propertyBlock);
+            _propertyBlock.SetColor(ColorProperty, color);
+            _propertyBlock.SetColor(BaseColorProperty, color);
+            platformRenderer.SetPropertyBlock(_propertyBlock);
+        }
+    }
+}

--- a/Assets/Scripts/Environment/FloatingPlatform.cs.meta
+++ b/Assets/Scripts/Environment/FloatingPlatform.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4c2af1c916694f668548ad33655d4051
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interaction.meta
+++ b/Assets/Scripts/Interaction.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 28f525c0e44f4ab9801510cc50f384e8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interaction/KeyItem.cs
+++ b/Assets/Scripts/Interaction/KeyItem.cs
@@ -1,0 +1,42 @@
+using UnityEngine;
+
+namespace YJ.Interaction
+{
+    [RequireComponent(typeof(Collider))]
+    public class KeyItem : MonoBehaviour
+    {
+        [SerializeField] private string keyId;
+        [SerializeField] private bool destroyOnPickup = true;
+
+        private void Reset()
+        {
+            var collider = GetComponent<Collider>();
+            collider.isTrigger = true;
+        }
+
+        private void OnValidate()
+        {
+            var collider = GetComponent<Collider>();
+            if (collider != null && !collider.isTrigger)
+            {
+                collider.isTrigger = true;
+            }
+        }
+
+        private void OnTriggerEnter(Collider other)
+        {
+            var keyring = other.GetComponentInParent<PlayerKeyring>();
+            if (keyring == null)
+            {
+                return;
+            }
+
+            keyring.AddKey(keyId);
+
+            if (destroyOnPickup)
+            {
+                Destroy(gameObject);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Interaction/KeyItem.cs.meta
+++ b/Assets/Scripts/Interaction/KeyItem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6ae5a4ae44644abf98224ce512694ab8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interaction/PlayerKeyring.cs
+++ b/Assets/Scripts/Interaction/PlayerKeyring.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace YJ.Interaction
+{
+    public class PlayerKeyring : MonoBehaviour
+    {
+        public static PlayerKeyring LocalPlayer { get; private set; }
+
+        [SerializeField] private List<string> startingKeys = new List<string>();
+
+        private readonly HashSet<string> _keys = new HashSet<string>();
+
+        private void Awake()
+        {
+            if (LocalPlayer != null && LocalPlayer != this)
+            {
+                Debug.LogWarning("Multiple PlayerKeyring instances detected. The newest instance will be used as the local player.");
+            }
+
+            LocalPlayer = this;
+
+            foreach (var key in startingKeys)
+            {
+                if (!string.IsNullOrWhiteSpace(key))
+                {
+                    _keys.Add(key);
+                }
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (LocalPlayer == this)
+            {
+                LocalPlayer = null;
+            }
+        }
+
+        public bool HasKey(string keyId)
+        {
+            if (string.IsNullOrWhiteSpace(keyId))
+            {
+                return true;
+            }
+
+            return _keys.Contains(keyId);
+        }
+
+        public void AddKey(string keyId)
+        {
+            if (string.IsNullOrWhiteSpace(keyId))
+            {
+                return;
+            }
+
+            if (_keys.Add(keyId))
+            {
+                Debug.Log($"Key collected: {keyId}");
+            }
+        }
+
+        public static bool TryGetPlayerPosition(out Vector3 position)
+        {
+            if (LocalPlayer != null)
+            {
+                position = LocalPlayer.transform.position;
+                return true;
+            }
+
+            position = Vector3.zero;
+            return false;
+        }
+    }
+}

--- a/Assets/Scripts/Interaction/PlayerKeyring.cs.meta
+++ b/Assets/Scripts/Interaction/PlayerKeyring.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4a26acb5eee14b3ea8e43dd553b62325
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add a configurable floating platform component that moves between editor-defined waypoints and shows its path
- implement key-based activation logic with color feedback to indicate locked/unlocked states
- create reusable key item and player keyring scripts to manage key pickup and availability checks

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68d9d5b4d10c832a9ed968d8123108b6